### PR TITLE
Add default template generation to cli

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 
 	"github.com/alecthomas/kong"
 	"github.com/charmbracelet/log"
+	"github.com/pkg/errors"
+	"github.com/sayden/counters"
 )
 
 var logger = log.New(os.Stderr)
@@ -18,6 +21,8 @@ var Cli struct {
 
 	// Vassal is used to generate a Vassal module for testing purposes.
 	Vassal vassal `cmd:"" help:"Create a vassal module for testing. It searches for the 'template.xml' in the same folder"` //FIXME
+
+	New NewDefaultTemplates `cmd:"" help:"Generates a new counter template file with default values"`
 }
 
 func main() {
@@ -31,4 +36,106 @@ func main() {
 	ctx.FatalIfErrorf(err)
 
 	log.Info("Done")
+}
+
+type NewDefaultTemplates struct {
+	OutputPath string `help:"Path to the folder to write the JSON" short:"o"`
+}
+
+func (i *NewDefaultTemplates) Run(ctx *kong.Context) error {
+	if i.OutputPath == "" {
+		return errors.New("output path is required")
+	}
+
+	err := generateNewCounterTemplate(i.OutputPath)
+	if err != nil {
+		return errors.Wrap(err, "could not generate new counter template")
+	}
+
+	return nil
+}
+
+func generateNewCounterTemplate(outputhPath string) error {
+	counterTemplate := counters.CounterTemplate{
+		Counters: []counters.Counter{
+			{
+				Texts: []counters.Text{
+					{
+						Settings: counters.Settings{
+							Position: 3,
+						},
+						String: "String",
+					},
+				},
+				Images: []counters.Image{
+					{
+						Settings: counters.Settings{
+							Position: 0,
+						},
+						Path: "path/to/image",
+					},
+				},
+			},
+		},
+		Rows:                      7,
+		Columns:                   7,
+		Mode:                      "template",
+		OutputFolder:              "generated",
+		PositionNumberForFilename: 0,
+		Prototypes: map[string]counters.CounterPrototype{
+			"prototype1": {
+				TextsPrototypes: []counters.TextPrototype{
+					{
+						StringList: []string{"String1", "String2"},
+					},
+				},
+				ImagesPrototypes: []counters.ImagePrototype{
+					{
+						Image: counters.Image{
+							Settings: counters.Settings{
+								Position: 0,
+							},
+						},
+						PathList: []string{"path/to/image1", "path/to/image2"},
+					},
+				},
+				Counter: counters.Counter{
+					Texts: []counters.Text{
+						{
+							Settings: counters.Settings{
+								Position: 3,
+							},
+							String: "String",
+						},
+					},
+					Images: []counters.Image{
+						{
+							Settings: counters.Settings{
+								Position: 0,
+							},
+							Path: "path/to/image",
+						},
+					},
+				},
+			},
+		},
+		Settings: counters.Settings{
+			FontPath:        "BebasNeue-Regular.ttf",
+			Width:           100,
+			Height:          100,
+			Margins:         3,
+			FontHeight:      10,
+			FontColorS:      "black",
+			BackgroundColor: "white",
+		},
+	}
+
+	f, err := os.Create(outputhPath)
+	if err != nil {
+		return errors.Wrap(err, "could not create output file")
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(counterTemplate)
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ var Cli struct {
 	// Vassal is used to generate a Vassal module for testing purposes.
 	Vassal vassal `cmd:"" help:"Create a vassal module for testing. It searches for the 'template.xml' in the same folder"` //FIXME
 
-	New NewDefaultTemplates `cmd:"" help:"Generates a new counter template file with default values"`
+	GenerateTemplate GenerateTemplate `cmd:"" help:"Generates a new counter template file with default values"`
 }
 
 func main() {
@@ -38,11 +38,11 @@ func main() {
 	log.Info("Done")
 }
 
-type NewDefaultTemplates struct {
+type GenerateTemplate struct {
 	OutputPath string `help:"Path to the folder to write the JSON" short:"o"`
 }
 
-func (i *NewDefaultTemplates) Run(ctx *kong.Context) error {
+func (i *GenerateTemplate) Run(ctx *kong.Context) error {
 	if i.OutputPath == "" {
 		return errors.New("output path is required")
 	}
@@ -55,7 +55,7 @@ func (i *NewDefaultTemplates) Run(ctx *kong.Context) error {
 	return nil
 }
 
-func generateNewCounterTemplate(outputhPath string) error {
+func generateNewCounterTemplate(outputPath string) error {
 	counterTemplate := counters.CounterTemplate{
 		Counters: []counters.Counter{
 			{
@@ -130,10 +130,11 @@ func generateNewCounterTemplate(outputhPath string) error {
 		},
 	}
 
-	f, err := os.Create(outputhPath)
+	f, err := os.Create(outputPath)
 	if err != nil {
 		return errors.Wrap(err, "could not create output file")
 	}
+	defer f.Close()
 
 	enc := json.NewEncoder(f)
 	enc.SetIndent("", "  ")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a command-line option to generate a new counter template file with default values.
	- Added functionality to specify an output path for the generated JSON file.

- **Bug Fixes**
	- Improved error handling for file creation and JSON encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->